### PR TITLE
fix: use zk os helper for nonce decoding

### DIFF
--- a/evm_tester/src/vm/zk_ee/mod.rs
+++ b/evm_tester/src/vm/zk_ee/mod.rs
@@ -268,7 +268,7 @@ impl ZkOS {
 
         match partial_data {
             Some(partial_data) => {
-                let nonce = partial_data.as_u64_array_ref()[3];
+                let nonce = zk_ee::system::reference_implementations::storage_format::account_code::PackedPartialAccountData::read_nonce_from_bytes32_encoding(partial_data);
                 nonce.into()
             },
             None => Default::default(),


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
Current implementation incorrectly decodes zk os nonces

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
